### PR TITLE
Minor fix in ddpm.py

### DIFF
--- a/ldm/models/diffusion/ddpm.py
+++ b/ldm/models/diffusion/ddpm.py
@@ -1027,7 +1027,7 @@ class LatentDiffusion(DDPM):
         loss_simple = self.get_loss(model_output, target, mean=False).mean([1, 2, 3])
         loss_dict.update({f'{prefix}/loss_simple': loss_simple.mean()})
 
-        logvar_t = self.logvar[t].to(self.device)
+        logvar_t = self.logvar.to(self.device)[t]
         loss = loss_simple / torch.exp(logvar_t) + logvar_t
         # loss = loss_simple / torch.exp(self.logvar) + self.logvar
         if self.learn_logvar:


### PR DESCRIPTION
first move `self.logvar` to `self.device`, and then index (line 1030, ddpm.py)

the current ordering gives the following error:
```
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```